### PR TITLE
fix: sync message signing — bind accounts, vault index, split discriminators

### DIFF
--- a/programs/squads_smart_account_program/src/instructions/settings_transaction_sync.rs
+++ b/programs/squads_smart_account_program/src/instructions/settings_transaction_sync.rs
@@ -1,7 +1,7 @@
 use anchor_lang::prelude::*;
 use anchor_lang::solana_program::hash::hash;
 
-use crate::{consensus::ConsensusAccount, consensus_trait::{Consensus, ConsensusAccountType}, errors::*, events::*, program::SquadsSmartAccountProgram, state::*, state::signer_v2::ExtraVerificationData, state::signer_v2::precompile::create_sync_consensus_message, utils::*, SmallVec};
+use crate::{consensus::ConsensusAccount, consensus_trait::{Consensus, ConsensusAccountType}, errors::*, events::*, program::SquadsSmartAccountProgram, state::*, state::signer_v2::ExtraVerificationData, state::signer_v2::precompile::create_sync_settings_message, utils::*, SmallVec};
 
 /// Arguments for synchronous settings transaction
 ///
@@ -66,7 +66,7 @@ impl<'info> SyncSettingsTransaction<'info> {
         let actions_bytes = args.actions.try_to_vec()
             .map_err(|_| SmartAccountError::InvalidPayload)?;
         let payload_hash = hash(&actions_bytes);
-        let message = create_sync_consensus_message(
+        let message = create_sync_settings_message(
             &consensus_account.key(),
             consensus_account.transaction_index(),
             &payload_hash.to_bytes(),

--- a/programs/squads_smart_account_program/src/instructions/transaction_execute_sync.rs
+++ b/programs/squads_smart_account_program/src/instructions/transaction_execute_sync.rs
@@ -10,7 +10,7 @@ use crate::{
     program::SquadsSmartAccountProgram,
     state::*,
     state::signer_v2::ExtraVerificationData,
-    state::signer_v2::precompile::create_sync_consensus_message,
+    state::signer_v2::precompile::create_sync_transaction_message,
     utils::{validate_synchronous_consensus, SynchronousTransactionMessage},
     SmallVec,
 };
@@ -133,9 +133,11 @@ impl<'info> SyncTransaction<'info> {
         let payload_bytes = args.payload.try_to_vec()
             .map_err(|_| SmartAccountError::InvalidPayload)?;
         let payload_hash = hash(&payload_bytes);
-        let message = create_sync_consensus_message(
+        let message = create_sync_transaction_message(
             &consensus_account.key(),
             consensus_account.transaction_index(),
+            args.account_index,
+            &remaining_accounts[accounts_start..],
             &payload_hash.to_bytes(),
         );
 

--- a/programs/squads_smart_account_program/src/instructions/transaction_execute_sync_legacy.rs
+++ b/programs/squads_smart_account_program/src/instructions/transaction_execute_sync_legacy.rs
@@ -10,7 +10,7 @@ use crate::{
     program::SquadsSmartAccountProgram,
     state::*,
     state::signer_v2::ExtraVerificationData,
-    state::signer_v2::precompile::create_sync_consensus_message,
+    state::signer_v2::precompile::create_sync_transaction_legacy_message,
     utils::{validate_synchronous_consensus, SynchronousTransactionMessage},
     SmallVec,
 };
@@ -65,12 +65,21 @@ impl LegacySyncTransaction<'_> {
         let settings = consensus_account.read_only_settings()?;
         settings.validate_account_index_unlocked(args.account_index)?;
 
+        // Compute the offset past signers + optional instructions sysvar.
+        let sysvar_offset = if remaining_accounts
+            .get(args.num_signers as usize)
+            .map_or(false, |acc| acc.key == &anchor_lang::solana_program::sysvar::instructions::ID)
+        { 1usize } else { 0usize };
+        let accounts_start = args.num_signers as usize + sysvar_offset;
+
         // Build message for external signer verification.
         // Hash the instructions payload so external signers commit to the exact instructions.
         let payload_hash = hash(&args.instructions);
-        let message = create_sync_consensus_message(
+        let message = create_sync_transaction_legacy_message(
             &consensus_account.key(),
             consensus_account.transaction_index(),
+            args.account_index,
+            &remaining_accounts[accounts_start..],
             &payload_hash.to_bytes(),
         );
 

--- a/programs/squads_smart_account_program/src/state/signer_v2/precompile/messages.rs
+++ b/programs/squads_smart_account_program/src/state/signer_v2/precompile/messages.rs
@@ -1,23 +1,6 @@
 use anchor_lang::prelude::*;
 use anchor_lang::solana_program::hash::{hash, Hasher};
 
-/// Create the expected message to sign for a given operation
-///
-/// Format: hash("squads-v2" || smart_account_key || operation_type || operation_data)
-pub fn create_signature_message(
-    smart_account: &Pubkey,
-    operation_type: &[u8],
-    operation_data: &[u8],
-) -> Hasher {
-    let mut hasher = Hasher::default();
-    hasher.hash(b"squads-v2");
-    hasher.hash(smart_account.as_ref());
-    hasher.hash(operation_type);
-    hasher.hash(operation_data);
-
-    hasher
-}
-
 /// Create message for vote signing
 pub fn create_vote_message(proposal_key: &Pubkey, vote: u8, transaction_index: u64) -> Hasher {
     let mut hasher = Hasher::default();
@@ -208,20 +191,78 @@ pub fn create_transaction_from_buffer_message(
     hasher
 }
 
-/// Create message for synchronous consensus verification
+/// Create message for synchronous transaction execution (v2 layout).
 ///
-/// This is used by external signers to prove they're authorizing a sync transaction.
-/// The payload_hash binds the signature to the specific instructions being executed,
-/// preventing a malicious transaction assembler from substituting a different payload.
+/// External signers commit to the exact execution context: which vault signs,
+/// which accounts are passed, and what instructions run. This prevents a relayer
+/// from swapping remaining_accounts or account_index after collecting signatures.
 ///
-/// Format: hash("squads-sync" || consensus_account_key || transaction_index || payload_hash)
-pub fn create_sync_consensus_message(
+/// Format: hash("sync_transaction_v2" || consensus_key || tx_index || account_index
+///              || num_accounts || for each: (key || is_writable) || payload_hash)
+pub fn create_sync_transaction_message(
+    consensus_account_key: &Pubkey,
+    transaction_index: u64,
+    account_index: u8,
+    remaining_accounts: &[AccountInfo],
+    payload_hash: &[u8; 32],
+) -> Hasher {
+    let mut hasher = Hasher::default();
+    hasher.hash(b"sync_transaction_v2");
+    hasher.hash(consensus_account_key.as_ref());
+    hasher.hash(&transaction_index.to_le_bytes());
+    hasher.hash(&[account_index]);
+    hasher.hash(&[remaining_accounts.len() as u8]);
+    for acc in remaining_accounts {
+        hasher.hash(acc.key.as_ref());
+        hasher.hash(&[acc.is_writable as u8]);
+    }
+    hasher.hash(payload_hash);
+
+    hasher
+}
+
+/// Create message for synchronous transaction execution (legacy layout).
+///
+/// Same security properties as the v2 variant but uses the legacy discriminator.
+///
+/// Format: hash("sync_transaction_legacy" || consensus_key || tx_index || account_index
+///              || num_accounts || for each: (key || is_writable) || payload_hash)
+pub fn create_sync_transaction_legacy_message(
+    consensus_account_key: &Pubkey,
+    transaction_index: u64,
+    account_index: u8,
+    remaining_accounts: &[AccountInfo],
+    payload_hash: &[u8; 32],
+) -> Hasher {
+    let mut hasher = Hasher::default();
+    hasher.hash(b"sync_transaction_legacy");
+    hasher.hash(consensus_account_key.as_ref());
+    hasher.hash(&transaction_index.to_le_bytes());
+    hasher.hash(&[account_index]);
+    hasher.hash(&[remaining_accounts.len() as u8]);
+    for acc in remaining_accounts {
+        hasher.hash(acc.key.as_ref());
+        hasher.hash(&[acc.is_writable as u8]);
+    }
+    hasher.hash(payload_hash);
+
+    hasher
+}
+
+/// Create message for synchronous settings transaction.
+///
+/// Settings sync doesn't execute CPI instructions against a vault, so there's
+/// no account_index or remaining_accounts to commit to. The payload_hash covers
+/// the exact settings actions being applied.
+///
+/// Format: hash("sync_settings_tx_v2" || consensus_key || tx_index || payload_hash)
+pub fn create_sync_settings_message(
     consensus_account_key: &Pubkey,
     transaction_index: u64,
     payload_hash: &[u8; 32],
 ) -> Hasher {
     let mut hasher = Hasher::default();
-    hasher.hash(b"squads-sync");
+    hasher.hash(b"sync_settings_tx_v2");
     hasher.hash(consensus_account_key.as_ref());
     hasher.hash(&transaction_index.to_le_bytes());
     hasher.hash(payload_hash);

--- a/tests/suites/v2/instructions/externalSignerNoncePersistence.ts
+++ b/tests/suites/v2/instructions/externalSignerNoncePersistence.ts
@@ -33,10 +33,14 @@ const { Permissions, Permission } = smartAccount.types;
 const programId = getTestProgramId();
 const connection = createLocalhostConnection();
 
-/** Build the sync consensus message matching on-chain create_sync_consensus_message */
-function buildSyncConsensusMessage(
-  settingsPda: PublicKey,
+/** Build the sync transaction message matching on-chain create_sync_transaction_message + nonce.
+ *  Binds signature to: discriminator, consensus key, tx index, account_index,
+ *  remaining accounts (key + is_writable), payload hash, and nonce. */
+function buildSyncTransactionMessage(
+  consensusKey: PublicKey,
   transactionIndex: bigint,
+  accountIndex: number,
+  executionAccounts: { pubkey: PublicKey; isWritable: boolean }[],
   nextNonce: bigint,
   payloadHash: Uint8Array
 ): Uint8Array {
@@ -45,11 +49,20 @@ function buildSyncConsensusMessage(
   const nonceBytes = Buffer.alloc(8);
   nonceBytes.writeBigUInt64LE(nextNonce);
 
+  const accountBuffers: Buffer[] = [];
+  for (const acc of executionAccounts) {
+    accountBuffers.push(acc.pubkey.toBuffer());
+    accountBuffers.push(Buffer.from([acc.isWritable ? 1 : 0]));
+  }
+
   return sha256(
     Buffer.concat([
-      Buffer.from("squads-sync", "utf-8"),
-      settingsPda.toBuffer(),
+      Buffer.from("sync_transaction_v2", "utf-8"),
+      consensusKey.toBuffer(),
       txIndexBytes,
+      Buffer.from([accountIndex]),
+      Buffer.from([executionAccounts.length]),
+      ...accountBuffers,
       Buffer.from(payloadHash),
       nonceBytes,
     ])
@@ -258,9 +271,11 @@ async function buildSyncTransferTx(opts: {
     Buffer.concat([Buffer.from([0x00]), payloadLenBytes, compiledIxBytes])
   );
 
-  const hashedMessage = buildSyncConsensusMessage(
+  const hashedMessage = buildSyncTransactionMessage(
     opts.settingsPda,
     transactionIndex,
+    0,
+    txAccounts,
     opts.nextNonce,
     payloadHash
   );
@@ -643,9 +658,11 @@ describe("Instructions / external_signer_nonce_persistence", () => {
     );
 
     // Build message with STALE nonce=1 (on-chain nonce is now 1, expected next=2)
-    const hashedMessage = buildSyncConsensusMessage(
+    const hashedMessage = buildSyncTransactionMessage(
       settingsPda,
       transactionIndex,
+      0,
+      txAccounts,
       1n, // STALE
       payloadHash
     );
@@ -908,9 +925,11 @@ describe("Instructions / external_signer_nonce_persistence", () => {
     // Build a WRONG payload hash — external signer signed a different payload
     const wrongPayloadHash = sha256(Buffer.from("wrong payload data"));
 
-    const hashedMessage = buildSyncConsensusMessage(
+    const hashedMessage = buildSyncTransactionMessage(
       settingsPda,
       transactionIndex,
+      0,
+      txAccounts,
       1n,
       wrongPayloadHash // Does not match actual instructions
     );

--- a/tests/suites/v2/instructions/externalSignerSecurity.ts
+++ b/tests/suites/v2/instructions/externalSignerSecurity.ts
@@ -33,11 +33,14 @@ const { Permissions, Permission } = smartAccount.types;
 const programId = getTestProgramId();
 const connection = createLocalhostConnection();
 
-/** Build the sync consensus message matching on-chain create_sync_consensus_message + nonce.
- *  payloadHash binds the signature to the specific instructions being executed. */
-function buildSyncConsensusMessage(
-  settingsPda: PublicKey,
+/** Build the sync transaction message matching on-chain create_sync_transaction_message + nonce.
+ *  Binds signature to: discriminator, consensus key, tx index, account_index,
+ *  remaining accounts (key + is_writable), payload hash, and nonce. */
+function buildSyncTransactionMessage(
+  consensusKey: PublicKey,
   transactionIndex: bigint,
+  accountIndex: number,
+  executionAccounts: { pubkey: PublicKey; isWritable: boolean }[],
   nextNonce: bigint,
   payloadHash: Uint8Array
 ): Uint8Array {
@@ -46,11 +49,20 @@ function buildSyncConsensusMessage(
   const nonceBytes = Buffer.alloc(8);
   nonceBytes.writeBigUInt64LE(nextNonce);
 
+  const accountBuffers: Buffer[] = [];
+  for (const acc of executionAccounts) {
+    accountBuffers.push(acc.pubkey.toBuffer());
+    accountBuffers.push(Buffer.from([acc.isWritable ? 1 : 0]));
+  }
+
   return sha256(
     Buffer.concat([
-      Buffer.from("squads-sync", "utf-8"),
-      settingsPda.toBuffer(),
+      Buffer.from("sync_transaction_v2", "utf-8"),
+      consensusKey.toBuffer(),
       txIndexBytes,
+      Buffer.from([accountIndex]),
+      Buffer.from([executionAccounts.length]),
+      ...accountBuffers,
       Buffer.from(payloadHash),
       nonceBytes,
     ])
@@ -681,9 +693,11 @@ describe("Instructions / external_signer_security", () => {
     const transactionIndex = BigInt(settings.transactionIndex.toString());
 
     // Each signer has nonce 0, so next_nonce = 1
-    const hashedMessage = buildSyncConsensusMessage(
+    const hashedMessage = buildSyncTransactionMessage(
       settingsPda,
       transactionIndex,
+      0,
+      txAccounts,
       1n,
       payloadHash
     );
@@ -811,9 +825,11 @@ describe("Instructions / external_signer_security", () => {
     const transactionIndex = BigInt(settings.transactionIndex.toString());
 
     // Both signers have nonce 0, next_nonce = 1
-    const hashedMessage = buildSyncConsensusMessage(
+    const hashedMessage = buildSyncTransactionMessage(
       settingsPda,
       transactionIndex,
+      0,
+      txAccounts,
       1n,
       payloadHash
     );

--- a/tests/suites/v2/instructions/mixedSignerSync.ts
+++ b/tests/suites/v2/instructions/mixedSignerSync.ts
@@ -225,18 +225,28 @@ describe("Instructions / mixed_signer_sync", () => {
       Buffer.concat([Buffer.from([0x00]), payloadLenBytes, compiledIxBytes])
     );
 
-    // Build sync consensus message:
-    // sha256("squads-sync" || settings_key || transaction_index_le || payload_hash || next_nonce_le)
+    // Build sync transaction message:
+    // sha256("sync_transaction_v2" || consensus_key || tx_index || account_index || num_accounts || for each: (key || is_writable) || payload_hash || nonce)
     const transactionIndex = BigInt(settings.transactionIndex.toString());
     const transactionIndexBytes = Buffer.alloc(8);
     transactionIndexBytes.writeBigUInt64LE(transactionIndex);
     const nonceBytes = Buffer.alloc(8);
     nonceBytes.writeBigUInt64LE(BigInt(1)); // next_nonce = current(0) + 1
+
+    const accountBuffers: Buffer[] = [];
+    for (const acc of txAccounts) {
+      accountBuffers.push(acc.pubkey.toBuffer());
+      accountBuffers.push(Buffer.from([acc.isWritable ? 1 : 0]));
+    }
+
     const hashedMessage = sha256(
       Buffer.concat([
-        Buffer.from("squads-sync", "utf-8"),
+        Buffer.from("sync_transaction_v2", "utf-8"),
         settingsPda.toBuffer(),
         transactionIndexBytes,
+        Buffer.from([0]), // account_index
+        Buffer.from([txAccounts.length]),
+        ...accountBuffers,
         Buffer.from(payloadHash),
         nonceBytes,
       ])


### PR DESCRIPTION
## Summary

Fixes three vulnerabilities in the sync transaction message signing path identified during audit review.

### 1. Remaining accounts not committed in signed message

External signers sign a hash that includes the instruction payload but not the account table those instructions operate on. A relayer who obtains valid signatures could swap `remaining_accounts` (e.g. replace a destination token account) while reusing the same signatures, redirecting funds.

Fix: hash each remaining account's pubkey and `is_writable` flag into the signed message.

### 2. `account_index` not committed in signed message

`account_index` determines which vault PDA gets signer authority for CPIs. It was passed as an instruction arg but never entered the signed hash. A relayer could change it to make a different vault sign.

Fix: include `account_index` as a byte in the signed message.

### 3. Shared discriminator between sync_transaction and sync_settings_transaction

Both used `"squads-sync"` as the message prefix. A signature for one could theoretically replay against the other if the payload bytes happen to deserialize under both interpretations.

Fix: split into three distinct slugs:
- `"sync_transaction_v2"` — for `sync_transaction_v2`
- `"sync_transaction_legacy"` — for legacy sync transactions
- `"sync_settings_tx_v2"` — for sync settings transactions

### Scope

All three fixes are **sync-path only**. Async transactions store accounts on-chain and go through proposal/vote governance, so they're not affected.

Also removed dead code: the unused `create_signature_message` function.

## Files changed

**Program:**
- `messages.rs` — replaced `create_sync_consensus_message` with 3 new functions, deleted dead `create_signature_message`
- `transaction_execute_sync.rs` — passes `account_index` + execution accounts to new message fn
- `transaction_execute_sync_legacy.rs` — same, with sysvar offset computation
- `settings_transaction_sync.rs` — uses new settings-specific message fn

**Tests:**
- `externalSignerSecurity.ts` — updated sync message builder
- `externalSignerNoncePersistence.ts` — updated sync message builder  
- `mixedSignerSync.ts` — updated inline message construction

## Test plan

- [x] Full V2 test suite: 189 passing, 1 expected failure (increment_account_index)
- [x] mixedSignerSync (5 mixed signers, precompile + syscall): passing
- [x] externalSignerSecurity (6 attack scenario tests): passing
- [x] externalSignerNoncePersistence (6 nonce tests): passing